### PR TITLE
Mosaic Variant Calling

### DIFF
--- a/DragenGE.sh
+++ b/DragenGE.sh
@@ -86,8 +86,6 @@ if [ $callmosaic == true ]; then
 	-r $dragen_ref \
 	--output-directory . \
 	--output-file-prefix "$seqId"_"$sampleId"_Mosaic \
-	--output-format BAM \
-	--enable-map-align-output true \
 	--tumor-fastq-list ../fastqs.csv \
 	--tumor-fastq-list-sample-id $sampleId \
 	--enable-duplicate-marking true \
@@ -98,9 +96,6 @@ if [ $callmosaic == true ]; then
 	--vc-target-bed ../config/"$panel"/"$panel"_ROI_"$genome_build".bed \
 	--vc-target-bed-padding 100 \
 	--strict-mode true \
-	--qc-coverage-region-1 ../config/"$panel"/"$panel"_ROI_"$genome_build".bed \
-	--qc-coverage-reports-1 cov_report \
-	--qc-coverage-filters-1 'mapq<20,bq<10' \
 	--enable-map-align true \
 	--alt-aware true
 	

--- a/DragenGE.sh
+++ b/DragenGE.sh
@@ -75,6 +75,37 @@ if [ -e "$seqId"_"$sampleId".bam ]; then
     echo "--bam-input "$sampleId"/"$seqId"_"$sampleId".bam \\" >> ../BAMList.txt
 fi
 
+if [ $callmosaic == true ]; then
+
+	echo Calling Mosaic Variants
+	
+	mkdir Mosaic_Calling
+        cd Mosaic_Calling
+
+	/opt/edico/bin/dragen \
+	-r $dragen_ref \
+	--output-directory . \
+	--output-file-prefix "$seqId"_"$sampleId"_Mosaic \
+	--output-format BAM \
+	--enable-map-align-output true \
+	--tumor-fastq-list ../fastqs.csv \
+	--tumor-fastq-list-sample-id $sampleId \
+	--enable-duplicate-marking true \
+	--enable-variant-caller true \
+	--vc-enable-joint-detection true \
+	--qc-cross-cont-vcf ../config/"$panel"/sample_cross_contamination_resource_"$genome_build".vcf \
+	--vc-sample-name "$sampleId" \
+	--vc-target-bed ../config/"$panel"/"$panel"_ROI_"$genome_build".bed \
+	--vc-target-bed-padding 100 \
+	--strict-mode true \
+	--qc-coverage-region-1 ../config/"$panel"/"$panel"_ROI_"$genome_build".bed \
+	--qc-coverage-reports-1 cov_report \
+	--qc-coverage-filters-1 'mapq<20,bq<10' \
+	--enable-map-align true \
+	--alt-aware true
+	
+	cd ../
+fi 
 
 # if all samples have been processed for the panel perform joint genotyping
 # expected number

--- a/config/IlluminaTruSightOne/IlluminaTruSightOne.variables
+++ b/config/IlluminaTruSightOne/IlluminaTruSightOne.variables
@@ -1,6 +1,7 @@
 post_processing_pipeline=dragenge_post_processing
 post_processing_pipeline_version=Build38
 callSV=true
+callmosaic=false
 dragen_ref="/staging/resources/human/reference/GRCh37/"
 genome_build="b37"
 fasta="human_g1k_v37.fasta"

--- a/config/IlluminaTruSightOne/IlluminaTruSightOne.variables
+++ b/config/IlluminaTruSightOne/IlluminaTruSightOne.variables
@@ -1,5 +1,5 @@
 post_processing_pipeline=dragenge_post_processing
-post_processing_pipeline_version=Build38
+post_processing_pipeline_version=development
 callSV=true
 callmosaic=false
 dragen_ref="/staging/resources/human/reference/GRCh37/"

--- a/config/IlluminaTruSightOne38/IlluminaTruSightOne.variables
+++ b/config/IlluminaTruSightOne38/IlluminaTruSightOne.variables
@@ -1,5 +1,5 @@
 post_processing_pipeline=dragenge_post_processing
-post_processing_pipeline_version=Build38
+post_processing_pipeline_version=development
 callSV=true
 callmosaic=false
 dragen_ref="/staging/resources/human/reference/GRCh38_masked/"

--- a/config/IlluminaTruSightOne38/IlluminaTruSightOne.variables
+++ b/config/IlluminaTruSightOne38/IlluminaTruSightOne.variables
@@ -1,6 +1,7 @@
 post_processing_pipeline=dragenge_post_processing
 post_processing_pipeline_version=Build38
 callSV=true
-dragen_ref="/staging/resources/human/reference/GRCh38_Dragen/"
+callmosaic=false
+dragen_ref="/staging/resources/human/reference/GRCh38_masked/"
 genome_build="hg38"
 fasta="GRCh38_full_analysis_set_plus_decoy_hla.fa"

--- a/config/NonocusWES37/NonocusWES37.variables
+++ b/config/NonocusWES37/NonocusWES37.variables
@@ -1,6 +1,7 @@
 post_processing_pipeline=dragenge_post_processing
 post_processing_pipeline_version=development
 callSV=true
+callmosaic=true
 dragen_ref="/staging/resources/human/reference/GRCh37/"
 genome_build="b37"
 fasta="human_g1k_v37.fasta"

--- a/config/NonocusWES38/NonocusWES38.variables
+++ b/config/NonocusWES38/NonocusWES38.variables
@@ -1,5 +1,5 @@
 post_processing_pipeline=dragenge_post_processing
-post_processing_pipeline_version=development
+post_processing_pipeline_version=mosaic
 callSV=true
 callmosaic=true
 dragen_ref="/staging/resources/human/reference/GRCh38_masked/"

--- a/config/NonocusWES38/NonocusWES38.variables
+++ b/config/NonocusWES38/NonocusWES38.variables
@@ -1,6 +1,7 @@
 post_processing_pipeline=dragenge_post_processing
 post_processing_pipeline_version=development
 callSV=true
+callmosaic=true
 dragen_ref="/staging/resources/human/reference/GRCh38_masked/"
 genome_build="hg38"
 fasta="GRCh38_full_analysis_set_plus_decoy_hla.fa"

--- a/config/NonocusWES38/NonocusWES38.variables
+++ b/config/NonocusWES38/NonocusWES38.variables
@@ -1,5 +1,5 @@
 post_processing_pipeline=dragenge_post_processing
-post_processing_pipeline_version=mosaic
+post_processing_pipeline_version=development
 callSV=true
 callmosaic=true
 dragen_ref="/staging/resources/human/reference/GRCh38_masked/"


### PR DESCRIPTION
- Addition of ability to call mosaic variants by running dragen in Somatic mode.
- Set by a flag in the variable file which is only true for NonocusWES. 
- Tested on NonocusWES38 using run 220106_NB551415_0317_AHVJCJAFX2. This doubled the run time from 1 hour and 5 minutes to 2 hours. 
- Set to not produce BAM files for mosaic calling so output is only around 30 MB bigger per sample. 
- Also tested TSO pipeline to ensure this still functioned correctly using run 210309_NB551319_0184_AHGKGNBGXH. 

Needed alongside pull request to dragenge_post_processing (https://github.com/AWGL/dragenge_post_processing/pull/10) and IlluminaQC (https://github.com/AWGL/IlluminaQC-WREN/pull/1).