### PR TITLE
add 1bp to 5 prime of exon in ROI BED file

### DIFF
--- a/DragenGE.sh
+++ b/DragenGE.sh
@@ -67,6 +67,8 @@ done
 --enable-map-align true \
 --alt-aware true
 
+touch "$seqId"_"$sampleId".mapping_metrics.csv
+
 if [ -e "$seqId"_"$sampleId".hard-filtered.gvcf.gz ]; then
     echo $sampleId/"$seqId"_"$sampleId".hard-filtered.gvcf.gz >> ../gVCFList.txt
 fi

--- a/DragenGE.sh
+++ b/DragenGE.sh
@@ -9,7 +9,7 @@ ulimit -S -n 65535
 
 # Usage: cd /staging/data/results/$seqId/$panel/$sampleId && bash DragenWGS.sh 
 
-version=2.0.0
+version=2.2.0
 
 ##############################################
 # SETUP                                      #


### PR DESCRIPTION
The padding for exons was 19bp on left hand wide and 20bp on right. Now corrected.

I had to merge and sort the BED files after so a few less lines in the new BED than the original.

Can we run a trio through on this BED to test?