### PR TITLE
Dragen v4.2.7

### DIFF
--- a/DragenGE.sh
+++ b/DragenGE.sh
@@ -53,6 +53,8 @@ done
 --fastq-list fastqs.csv \
 --fastq-list-sample-id $sampleId \
 --read-trimmers adapter \
+--trim-adapter-read1 true \
+--trim-adapter-read2 true \
 --enable-duplicate-marking true \
 --enable-variant-caller true \
 --vc-enable-joint-detection true \

--- a/DragenGE.sh
+++ b/DragenGE.sh
@@ -52,9 +52,6 @@ done
 --enable-map-align-output true \
 --fastq-list fastqs.csv \
 --fastq-list-sample-id $sampleId \
---read-trimmers adapter \
---trim-adapter-read1 true \
---trim-adapter-read2 true \
 --enable-duplicate-marking true \
 --enable-variant-caller true \
 --vc-enable-joint-detection true \

--- a/DragenGE.sh
+++ b/DragenGE.sh
@@ -52,6 +52,7 @@ done
 --enable-map-align-output true \
 --fastq-list fastqs.csv \
 --fastq-list-sample-id $sampleId \
+--read-trimmers adapter \
 --enable-duplicate-marking true \
 --enable-variant-caller true \
 --vc-enable-joint-detection true \

--- a/config/NonocusWES38/NonocusWES38.variables
+++ b/config/NonocusWES38/NonocusWES38.variables
@@ -1,6 +1,6 @@
 post_processing_pipeline=dragenge_post_processing
 post_processing_pipeline_version=master
 callSV=true
-dragen_ref="/staging/resources/human/reference/GRCh38_masked/"
+dragen_ref="/staging/resources/human/reference/GRCh38_masked_v9/"
 genome_build="hg38"
 fasta="GRCh38_full_analysis_set_plus_decoy_hla.fa"


### PR DESCRIPTION
Closes #15.

Updates needed for Dragen v4.2.7 - update to reference genome hash only. Tested on 211215_NB551415_0311_AHC3C3BGXK (NextSeq run) and 211215_A00748_0193_AHCNL5DRXY (NovaSeq run). 

DO NOT GO LIVE UNTIL DRAGEN VERSION UPDATED. Need to coordinate with changes to AutoQC and dragenge_post_processing. 